### PR TITLE
Fixed warnings, fixed 'toport' bug, added Xcode project

### DIFF
--- a/Xcode/macOS/config.h
+++ b/Xcode/macOS/config.h
@@ -1,0 +1,291 @@
+/* src/config.h.  Generated from config.h.in by configure.  */
+/* src/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* rl_completion_entry_function has the wrong return type */
+#define HAS_LIBEDIT_COMPLETION_ENTRY_BUG 1
+
+/* Define to 1 if you have the `alloca' function. */
+/* #undef HAVE_ALLOCA */
+
+/* Define to 1 if you have the <alloca.h> header file. */
+#define HAVE_ALLOCA_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H 1
+
+/* Define to 1 if you have the `fprintf' function. */
+#define HAVE_FPRINTF 1
+
+/* Define to 1 if the system has the `deprecated' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_DEPRECATED 1
+
+/* Define to 1 if the system has the `pure' function attribute */
+#define HAVE_FUNC_ATTRIBUTE_PURE 1
+
+/* Define to 1 if you have the `getline' function. */
+#define HAVE_GETLINE 1
+
+/* Define to 1 if you have the `getloadavg' function. */
+#define HAVE_GETLOADAVG 1
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `readline' library (-lreadline). */
+#define HAVE_LIBREADLINE 1
+
+/* Define to 1 if you have the `malloc' function. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the `memcmp' function. */
+#define HAVE_MEMCMP 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Set if OpenSSL is present */
+/* #undef HAVE_OPENSSL */
+
+/* Set if OpenSSL has DTLSv1_method() */
+/* #undef HAVE_OPENSSL_DTLSV1_METHOD */
+
+/* Set if OpenSSL has DTLS_method() */
+/* #undef HAVE_OPENSSL_DTLS_METHOD */
+
+/* Set if OpenSSL has SSL_CONF_CTX_new() */
+/* #undef HAVE_OPENSSL_SSL_CONF_CTX_NEW */
+
+/* Set if OpenSSL has SSL_CONF_finish() */
+/* #undef HAVE_OPENSSL_SSL_CONF_FINISH */
+
+/* Define to 1 if you have the `printf' function. */
+#define HAVE_PRINTF 1
+
+/* Define if you have POSIX threads libraries and header files. */
+#define HAVE_PTHREAD 1
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have the `rl_set_prompt' function. */
+#define HAVE_RL_SET_PROMPT 1
+
+/* Define to 1 if you have the `setenv' function. */
+#define HAVE_SETENV 1
+
+/* Define to 1 if you have the `snprintf' function. */
+#define HAVE_SNPRINTF 1
+
+/* Define to 1 if you have the `sprintf' function. */
+#define HAVE_SPRINTF 1
+
+/* Define to 1 if you have the <stdarg.h> header file. */
+#define HAVE_STDARG_H 1
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stddef.h> header file. */
+#define HAVE_STDDEF_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `stpncpy' function. */
+#define HAVE_STPNCPY 1
+
+/* Define to 1 if you have the `strchr' function. */
+#define HAVE_STRCHR 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the `strerror' function. */
+#define HAVE_STRERROR 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strlcat' function. */
+#define HAVE_STRLCAT 1
+
+/* Define to 1 if you have the `strlcpy' function. */
+#define HAVE_STRLCPY 1
+
+/* Define to 1 if you have the `strndup' function. */
+#define HAVE_STRNDUP 1
+
+/* Define to 1 if you have the `strstr' function. */
+#define HAVE_STRSTR 1
+
+/* Define to 1 if you have the `strtol' function. */
+#define HAVE_STRTOL 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the `vsnprintf' function. */
+#define HAVE_VSNPRINTF 1
+
+/* Define to 1 if you have the `vsprintf' function. */
+#define HAVE_VSPRINTF 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* . */
+#define NYOCI_API_EXTERN __attribute__((visibility("default"))) extern
+
+/* . */
+/* #undef NYOCI_AVOID_MALLOC */
+
+/* . */
+/* #undef NYOCI_AVOID_PRINTF */
+
+/* . */
+/* #undef NYOCI_CONF_NODE_ROUTER */
+
+/* . */
+/* #undef NYOCI_CONF_TRANS_ENABLE_BLOCK2 */
+
+/* . */
+/* #undef NYOCI_CONF_TRANS_ENABLE_OBSERVING */
+
+/* . */
+/* #undef NYOCI_EMBEDDED */
+
+/* . */
+#define NYOCI_INTERNAL_EXTERN __attribute__((visibility("default"))) extern
+
+/* . */
+/* #undef NYOCI_MAX_OBSERVERS */
+
+/* . */
+/* #undef NYOCI_MAX_VHOSTS */
+
+/* LibNyoci network abstraction */
+#define NYOCI_PLAT_NET posix
+
+/* . */
+/* #undef NYOCI_PLAT_NET_POSIX_FAMILY */
+
+/* LibNyoci TLS abstraction */
+/* #undef NYOCI_PLAT_TLS */
+
+/* . */
+/* #undef NYOCI_SINGLETON */
+
+/* . */
+/* #undef NYOCI_USE_CASCADE_COUNT */
+
+/* Name of package */
+#define PACKAGE "libnyoci"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://github.com/darconeous/libnyoci/"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "LibNyoci"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "LibNyoci 0.07.00rc1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libnyoci"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "http://libnyoci.org/"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "0.07.00rc1"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* Source version */
+#define SOURCE_VERSION "0.07.00rc1-6-g5ad1f3d"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+#define TIME_WITH_SYS_TIME 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Version number of package */
+#define VERSION "0.07.00rc1"
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */
+
+/* Define to empty if `const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to `int' if <sys/types.h> does not define. */
+/* #undef ssize_t */
+
+/* Define to empty if the keyword `volatile' does not work. Warning: valid
+   code using `volatile' can become incorrect without. Disable with care. */
+/* #undef volatile */

--- a/Xcode/macOS/nyoci-config.h
+++ b/Xcode/macOS/nyoci-config.h
@@ -1,0 +1,125 @@
+/* src/libnyoci/nyoci-config.h.  Generated from nyoci-config.h.in by configure.  */
+/*!	@file nyoci-config.h
+**	@author Robert Quattlebaum <darco@deepdarc.com>
+**	@brief LibNyoci Build Options
+**
+**	Copyright (C) 2017 Robert Quattlebaum
+**
+**	Permission is hereby granted, free of charge, to any person
+**	obtaining a copy of this software and associated
+**	documentation files (the "Software"), to deal in the
+**	Software without restriction, including without limitation
+**	the rights to use, copy, modify, merge, publish, distribute,
+**	sublicense, and/or sell copies of the Software, and to
+**	permit persons to whom the Software is furnished to do so,
+**	subject to the following conditions:
+**
+**	The above copyright notice and this permission notice shall
+**	be included in all copies or substantial portions of the
+**	Software.
+**
+**	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+**	KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+**	WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+**	PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+**	OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+**	OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+**	OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+**	SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/* #undef NYOCI_EMBEDDED */
+
+/* #undef NYOCI_SINGLETON */
+
+/* #undef NYOCI_PLAT_NET_POSIX_FAMILY */
+
+#define NYOCI_PLAT_NET posix
+
+/* #undef NYOCI_PLAT_TLS */
+
+/* #undef NYOCI_AVOID_MALLOC */
+
+/* #undef NYOCI_AVOID_PRINTF */
+
+/* #undef NYOCI_DEFAULT_PORT */
+
+/* #undef NYOCI_CONF_DUPE_BUFFER_SIZE */
+
+/* #undef NYOCI_CONF_ENABLE_VHOSTS */
+
+/* #undef NYOCI_CONF_MAX_ALLOCED_NODES */
+
+/* #undef NYOCI_CONF_MAX_GROUPS */
+
+/* #undef NYOCI_CONF_MAX_OBSERVERS */
+
+/* #undef NYOCI_CONF_MAX_PAIRINGS */
+
+/* #undef NYOCI_CONF_MAX_TIMEOUT */
+
+/* #undef NYOCI_CONF_NODE_ROUTER */
+
+/* #undef NYOCI_CONF_TRANS_ENABLE_BLOCK2 */
+
+/* #undef NYOCI_CONF_TRANS_ENABLE_OBSERVING */
+
+/* #undef NYOCI_CONF_USE_DNS */
+
+/* #undef NYOCI_ADD_NEWLINES_TO_LIST_OUTPUT */
+
+/* #undef NYOCI_ASYNC_RESPONSE_MAX_LENGTH */
+
+/* #undef NYOCI_DEBUG_INBOUND_DROP_PERCENT */
+
+/* #undef NYOCI_DEBUG_OUTBOUND_DROP_PERCENT */
+
+/* #undef NYOCI_MAX_CASCADE_COUNT */
+
+/* #undef NYOCI_MAX_CONTENT_LENGTH */
+
+/* #undef NYOCI_MAX_OBSERVERS */
+
+/* #undef NYOCI_MAX_PACKET_LENGTH */
+
+/* #undef NYOCI_MAX_PATH_LENGTH */
+
+/* #undef NYOCI_MAX_URI_LENGTH */
+
+/* #undef NYOCI_MAX_VHOSTS */
+
+/* #undef NYOCI_TRANSACTION_BURST_COUNT */
+
+/* #undef NYOCI_TRANSACTION_BURST_TIMEOUT_MAX */
+
+/* #undef NYOCI_TRANSACTION_BURST_TIMEOUT_MIN */
+
+/* #undef NYOCI_THREAD_SAFE */
+
+/* #undef NYOCI_NODE_ROUTER_USE_BTREE */
+
+/* #undef NYOCI_OBSERVATION_DEFAULT_MAX_AGE */
+
+/* #undef NYOCI_OBSERVATION_KEEPALIVE_INTERVAL */
+
+/* #undef NYOCI_OBSERVER_CON_EVENT_EXPIRATION */
+
+/* #undef NYOCI_OBSERVER_NON_EVENT_EXPIRATION */
+
+/* #undef NYOCI_TRANSACTIONS_USE_BTREE */
+
+/* #undef NYOCI_TRANSACTION_BURST_COUNT */
+
+/* #undef NYOCI_TRANSACTION_POOL_SIZE */
+
+/* #undef NYOCI_USE_CASCADE_COUNT */
+
+/* #undef NYOCI_VARIABLE_MAX_KEY_LENGTH */
+
+/* #undef NYOCI_VARIABLE_MAX_VALUE_LENGTH */
+
+#define NYOCI_INTERNAL_EXTERN __attribute__((visibility("default"))) extern
+
+#define NYOCI_API_EXTERN __attribute__((visibility("default"))) extern
+
+/* #undef NYOCI_DEPRECATED */

--- a/Xcode/nyoci.xcodeproj/project.pbxproj
+++ b/Xcode/nyoci.xcodeproj/project.pbxproj
@@ -1,0 +1,939 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		277A057A20AC959F00970354 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A044020AC959E00970354 /* config.h */; };
+		277A059820AC959F00970354 /* assert-macros.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A048920AC959E00970354 /* assert-macros.h */; };
+		277A059920AC959F00970354 /* btree.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A048A20AC959E00970354 /* btree.c */; };
+		277A059A20AC959F00970354 /* btree.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A048B20AC959E00970354 /* btree.h */; };
+		277A059B20AC959F00970354 /* coap.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A048C20AC959E00970354 /* coap.c */; };
+		277A059C20AC959F00970354 /* coap.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A048D20AC959E00970354 /* coap.h */; };
+		277A059D20AC959F00970354 /* fasthash.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A048E20AC959E00970354 /* fasthash.c */; };
+		277A059E20AC959F00970354 /* fasthash.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A048F20AC959E00970354 /* fasthash.h */; };
+		277A059F20AC959F00970354 /* libnyoci.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A049020AC959E00970354 /* libnyoci.h */; };
+		277A05AF20AC959F00970354 /* ll.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04B220AC959F00970354 /* ll.h */; };
+		277A05B120AC959F00970354 /* nyoci-async.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04B620AC959F00970354 /* nyoci-async.c */; };
+		277A05B220AC959F00970354 /* nyoci-async.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04B720AC959F00970354 /* nyoci-async.h */; };
+		277A05B320AC959F00970354 /* nyoci-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04B820AC959F00970354 /* nyoci-config.h */; };
+		277A05B420AC959F00970354 /* nyoci-defaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04BA20AC959F00970354 /* nyoci-defaults.h */; };
+		277A05B520AC959F00970354 /* nyoci-dupe.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04BB20AC959F00970354 /* nyoci-dupe.c */; };
+		277A05B620AC959F00970354 /* nyoci-dupe.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04BC20AC959F00970354 /* nyoci-dupe.h */; };
+		277A05B720AC959F00970354 /* nyoci-helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04BD20AC959F00970354 /* nyoci-helpers.h */; };
+		277A05B820AC959F00970354 /* nyoci-inbound.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04BE20AC959F00970354 /* nyoci-inbound.c */; };
+		277A05B920AC959F00970354 /* nyoci-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04BF20AC959F00970354 /* nyoci-internal.h */; };
+		277A05BA20AC959F00970354 /* nyoci-logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04C020AC959F00970354 /* nyoci-logging.h */; };
+		277A05BB20AC959F00970354 /* nyoci-missing.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04C120AC959F00970354 /* nyoci-missing.c */; };
+		277A05BC20AC959F00970354 /* nyoci-missing.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04C220AC959F00970354 /* nyoci-missing.h */; };
+		277A05BD20AC959F00970354 /* nyoci-observable.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04C320AC959F00970354 /* nyoci-observable.c */; };
+		277A05BE20AC959F00970354 /* nyoci-observable.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04C420AC959F00970354 /* nyoci-observable.h */; };
+		277A05BF20AC959F00970354 /* nyoci-opts.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04C520AC959F00970354 /* nyoci-opts.h */; };
+		277A05C020AC959F00970354 /* nyoci-outbound.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04C620AC959F00970354 /* nyoci-outbound.c */; };
+		277A05C120AC959F00970354 /* nyoci-plat-net-func.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04C720AC959F00970354 /* nyoci-plat-net-func.h */; };
+		277A05C220AC959F00970354 /* nyoci-plat-tls-func.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04C820AC959F00970354 /* nyoci-plat-tls-func.h */; };
+		277A05C320AC959F00970354 /* nyoci-session.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04C920AC959F00970354 /* nyoci-session.c */; };
+		277A05C420AC959F00970354 /* nyoci-session.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04CA20AC959F00970354 /* nyoci-session.h */; };
+		277A05C520AC959F00970354 /* nyoci-status.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04CB20AC959F00970354 /* nyoci-status.h */; };
+		277A05C620AC959F00970354 /* nyoci-timer.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04CC20AC959F00970354 /* nyoci-timer.c */; };
+		277A05C720AC959F00970354 /* nyoci-timer.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04CD20AC959F00970354 /* nyoci-timer.h */; };
+		277A05C820AC959F00970354 /* nyoci-transaction.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04CE20AC959F00970354 /* nyoci-transaction.c */; };
+		277A05C920AC959F00970354 /* nyoci-transaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04CF20AC959F00970354 /* nyoci-transaction.h */; };
+		277A05CA20AC959F00970354 /* nyoci.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04D020AC959F00970354 /* nyoci.c */; };
+		277A05CB20AC959F00970354 /* string-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04D220AC959F00970354 /* string-utils.c */; };
+		277A05CC20AC959F00970354 /* string-utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04D320AC959F00970354 /* string-utils.h */; };
+		277A05CD20AC959F00970354 /* url-helpers.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04D420AC959F00970354 /* url-helpers.c */; };
+		277A05CE20AC959F00970354 /* url-helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04D520AC959F00970354 /* url-helpers.h */; };
+		277A05D520AC959F00970354 /* libnyociextra.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04E420AC959F00970354 /* libnyociextra.h */; };
+		277A05D720AC959F00970354 /* nyoci-list.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04EB20AC959F00970354 /* nyoci-list.c */; };
+		277A05D920AC959F00970354 /* nyoci-node-router.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04EE20AC959F00970354 /* nyoci-node-router.c */; };
+		277A05DA20AC959F00970354 /* nyoci-node-router.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04EF20AC959F00970354 /* nyoci-node-router.h */; };
+		277A05DC20AC959F00970354 /* nyoci-var-handler.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04F220AC959F00970354 /* nyoci-var-handler.c */; };
+		277A05DD20AC959F00970354 /* nyoci-var-handler.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04F320AC959F00970354 /* nyoci-var-handler.h */; };
+		277A05E020AC959F00970354 /* fgetln.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04FA20AC959F00970354 /* fgetln.h */; };
+		277A05E120AC959F00970354 /* getline.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04FB20AC959F00970354 /* getline.c */; };
+		277A05E420AC959F00970354 /* strlcat.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A050620AC959F00970354 /* strlcat.c */; };
+		277A05E520AC959F00970354 /* strlcat.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A050720AC959F00970354 /* strlcat.h */; };
+		277A05E620AC959F00970354 /* strlcat_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A050820AC959F00970354 /* strlcat_test.c */; };
+		277A05E820AC959F00970354 /* strlcpy.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A051020AC959F00970354 /* strlcpy.c */; };
+		277A05E920AC959F00970354 /* strlcpy.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A051120AC959F00970354 /* strlcpy.h */; };
+		277A05EA20AC959F00970354 /* strlcpy_test.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A051220AC959F00970354 /* strlcpy_test.c */; };
+		277A05EC20AC959F00970354 /* cmd_delete.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A051F20AC959F00970354 /* cmd_delete.h */; };
+		277A05EE20AC959F00970354 /* cmd_get.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A052120AC959F00970354 /* cmd_get.h */; };
+		277A05F020AC959F00970354 /* cmd_list.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A052320AC959F00970354 /* cmd_list.h */; };
+		277A05F220AC959F00970354 /* cmd_post.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A052520AC959F00970354 /* cmd_post.h */; };
+		277A05F420AC959F00970354 /* cmd_repeat.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A052720AC959F00970354 /* cmd_repeat.h */; };
+		277A05F620AC959F00970354 /* help.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A052920AC959F00970354 /* help.h */; };
+		277A060020AC959F00970354 /* nyocictl.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A053620AC959F00970354 /* nyocictl.h */; };
+		277A060520AC959F00970354 /* nyoci-plat-net-internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A054520AC959F00970354 /* nyoci-plat-net-internal.h */; };
+		277A060620AC959F00970354 /* nyoci-plat-net.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A054620AC959F00970354 /* nyoci-plat-net.c */; };
+		277A060720AC959F00970354 /* nyoci-plat-net.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A054720AC959F00970354 /* nyoci-plat-net.h */; };
+		277A060E20AC959F00970354 /* nyoci-plat-tls.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A055920AC959F00970354 /* nyoci-plat-tls.h */; };
+		277A061520AC959F00970354 /* plugtest-server.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A056C20AC959F00970354 /* plugtest-server.h */; };
+		277A061920AC959F00970354 /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A057920AC959F00970354 /* version.h */; };
+		277A062520AC9B0C00970354 /* example-2.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A045420AC959E00970354 /* example-2.c */; };
+		277A062920AC9B1E00970354 /* libnyoci.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 277A043720AC954900970354 /* libnyoci.a */; };
+		277A063520AC9C5500970354 /* cmd_delete.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A051E20AC959F00970354 /* cmd_delete.c */; };
+		277A063620AC9C5500970354 /* cmd_get.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A052020AC959F00970354 /* cmd_get.c */; };
+		277A063720AC9C5500970354 /* cmd_list.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A052220AC959F00970354 /* cmd_list.c */; };
+		277A063820AC9C5500970354 /* cmd_post.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A052420AC959F00970354 /* cmd_post.c */; };
+		277A063920AC9C5500970354 /* cmd_repeat.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A052620AC959F00970354 /* cmd_repeat.c */; };
+		277A063A20AC9C5500970354 /* help.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A052820AC959F00970354 /* help.c */; };
+		277A063B20AC9C5500970354 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A052A20AC959F00970354 /* main.c */; };
+		277A063E20AC9C6800970354 /* libnyoci.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 277A043720AC954900970354 /* libnyoci.a */; };
+		277A064020ACAA8400970354 /* libreadline.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 277A063F20ACAA8400970354 /* libreadline.tbd */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		277A062620AC9B1900970354 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 277A042F20AC954900970354 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 277A043620AC954900970354;
+			remoteInfo = nyoci;
+		};
+		277A063C20AC9C6300970354 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 277A042F20AC954900970354 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 277A043620AC954900970354;
+			remoteInfo = nyoci;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		277A061C20AC9B0200970354 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		277A062C20AC9C5000970354 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		277A043720AC954900970354 /* libnyoci.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libnyoci.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		277A044020AC959E00970354 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		277A045120AC959E00970354 /* example-1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-1.c"; sourceTree = "<group>"; };
+		277A045420AC959E00970354 /* example-2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-2.c"; sourceTree = "<group>"; };
+		277A045720AC959E00970354 /* example-3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-3.c"; sourceTree = "<group>"; };
+		277A045A20AC959E00970354 /* example-4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-4.c"; sourceTree = "<group>"; };
+		277A045D20AC959E00970354 /* example-multicast-request.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-multicast-request.c"; sourceTree = "<group>"; };
+		277A048920AC959E00970354 /* assert-macros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "assert-macros.h"; sourceTree = "<group>"; };
+		277A048A20AC959E00970354 /* btree.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = btree.c; sourceTree = "<group>"; };
+		277A048B20AC959E00970354 /* btree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = btree.h; sourceTree = "<group>"; };
+		277A048C20AC959E00970354 /* coap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = coap.c; sourceTree = "<group>"; };
+		277A048D20AC959E00970354 /* coap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coap.h; sourceTree = "<group>"; };
+		277A048E20AC959E00970354 /* fasthash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = fasthash.c; sourceTree = "<group>"; };
+		277A048F20AC959E00970354 /* fasthash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fasthash.h; sourceTree = "<group>"; };
+		277A049020AC959E00970354 /* libnyoci.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libnyoci.h; sourceTree = "<group>"; };
+		277A04B220AC959F00970354 /* ll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ll.h; sourceTree = "<group>"; };
+		277A04B620AC959F00970354 /* nyoci-async.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-async.c"; sourceTree = "<group>"; };
+		277A04B720AC959F00970354 /* nyoci-async.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-async.h"; sourceTree = "<group>"; };
+		277A04B820AC959F00970354 /* nyoci-config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-config.h"; sourceTree = "<group>"; };
+		277A04BA20AC959F00970354 /* nyoci-defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-defaults.h"; sourceTree = "<group>"; };
+		277A04BB20AC959F00970354 /* nyoci-dupe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-dupe.c"; sourceTree = "<group>"; };
+		277A04BC20AC959F00970354 /* nyoci-dupe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-dupe.h"; sourceTree = "<group>"; };
+		277A04BD20AC959F00970354 /* nyoci-helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-helpers.h"; sourceTree = "<group>"; };
+		277A04BE20AC959F00970354 /* nyoci-inbound.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-inbound.c"; sourceTree = "<group>"; };
+		277A04BF20AC959F00970354 /* nyoci-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-internal.h"; sourceTree = "<group>"; };
+		277A04C020AC959F00970354 /* nyoci-logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-logging.h"; sourceTree = "<group>"; };
+		277A04C120AC959F00970354 /* nyoci-missing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-missing.c"; sourceTree = "<group>"; };
+		277A04C220AC959F00970354 /* nyoci-missing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-missing.h"; sourceTree = "<group>"; };
+		277A04C320AC959F00970354 /* nyoci-observable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-observable.c"; sourceTree = "<group>"; };
+		277A04C420AC959F00970354 /* nyoci-observable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-observable.h"; sourceTree = "<group>"; };
+		277A04C520AC959F00970354 /* nyoci-opts.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-opts.h"; sourceTree = "<group>"; };
+		277A04C620AC959F00970354 /* nyoci-outbound.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-outbound.c"; sourceTree = "<group>"; };
+		277A04C720AC959F00970354 /* nyoci-plat-net-func.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net-func.h"; sourceTree = "<group>"; };
+		277A04C820AC959F00970354 /* nyoci-plat-tls-func.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-tls-func.h"; sourceTree = "<group>"; };
+		277A04C920AC959F00970354 /* nyoci-session.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-session.c"; sourceTree = "<group>"; };
+		277A04CA20AC959F00970354 /* nyoci-session.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-session.h"; sourceTree = "<group>"; };
+		277A04CB20AC959F00970354 /* nyoci-status.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-status.h"; sourceTree = "<group>"; };
+		277A04CC20AC959F00970354 /* nyoci-timer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-timer.c"; sourceTree = "<group>"; };
+		277A04CD20AC959F00970354 /* nyoci-timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-timer.h"; sourceTree = "<group>"; };
+		277A04CE20AC959F00970354 /* nyoci-transaction.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-transaction.c"; sourceTree = "<group>"; };
+		277A04CF20AC959F00970354 /* nyoci-transaction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-transaction.h"; sourceTree = "<group>"; };
+		277A04D020AC959F00970354 /* nyoci.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = nyoci.c; sourceTree = "<group>"; };
+		277A04D220AC959F00970354 /* string-utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "string-utils.c"; sourceTree = "<group>"; };
+		277A04D320AC959F00970354 /* string-utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "string-utils.h"; sourceTree = "<group>"; };
+		277A04D420AC959F00970354 /* url-helpers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "url-helpers.c"; sourceTree = "<group>"; };
+		277A04D520AC959F00970354 /* url-helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "url-helpers.h"; sourceTree = "<group>"; };
+		277A04E420AC959F00970354 /* libnyociextra.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = libnyociextra.h; sourceTree = "<group>"; };
+		277A04EB20AC959F00970354 /* nyoci-list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-list.c"; sourceTree = "<group>"; };
+		277A04EE20AC959F00970354 /* nyoci-node-router.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-node-router.c"; sourceTree = "<group>"; };
+		277A04EF20AC959F00970354 /* nyoci-node-router.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-node-router.h"; sourceTree = "<group>"; };
+		277A04F220AC959F00970354 /* nyoci-var-handler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-var-handler.c"; sourceTree = "<group>"; };
+		277A04F320AC959F00970354 /* nyoci-var-handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-var-handler.h"; sourceTree = "<group>"; };
+		277A04FA20AC959F00970354 /* fgetln.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fgetln.h; sourceTree = "<group>"; };
+		277A04FB20AC959F00970354 /* getline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = getline.c; sourceTree = "<group>"; };
+		277A050620AC959F00970354 /* strlcat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = strlcat.c; sourceTree = "<group>"; };
+		277A050720AC959F00970354 /* strlcat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strlcat.h; sourceTree = "<group>"; };
+		277A050820AC959F00970354 /* strlcat_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = strlcat_test.c; sourceTree = "<group>"; };
+		277A051020AC959F00970354 /* strlcpy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = strlcpy.c; sourceTree = "<group>"; };
+		277A051120AC959F00970354 /* strlcpy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = strlcpy.h; sourceTree = "<group>"; };
+		277A051220AC959F00970354 /* strlcpy_test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = strlcpy_test.c; sourceTree = "<group>"; };
+		277A051E20AC959F00970354 /* cmd_delete.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmd_delete.c; sourceTree = "<group>"; };
+		277A051F20AC959F00970354 /* cmd_delete.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmd_delete.h; sourceTree = "<group>"; };
+		277A052020AC959F00970354 /* cmd_get.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmd_get.c; sourceTree = "<group>"; };
+		277A052120AC959F00970354 /* cmd_get.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmd_get.h; sourceTree = "<group>"; };
+		277A052220AC959F00970354 /* cmd_list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmd_list.c; sourceTree = "<group>"; };
+		277A052320AC959F00970354 /* cmd_list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmd_list.h; sourceTree = "<group>"; };
+		277A052420AC959F00970354 /* cmd_post.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmd_post.c; sourceTree = "<group>"; };
+		277A052520AC959F00970354 /* cmd_post.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmd_post.h; sourceTree = "<group>"; };
+		277A052620AC959F00970354 /* cmd_repeat.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cmd_repeat.c; sourceTree = "<group>"; };
+		277A052720AC959F00970354 /* cmd_repeat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmd_repeat.h; sourceTree = "<group>"; };
+		277A052820AC959F00970354 /* help.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = help.c; sourceTree = "<group>"; };
+		277A052920AC959F00970354 /* help.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = help.h; sourceTree = "<group>"; };
+		277A052A20AC959F00970354 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		277A053620AC959F00970354 /* nyocictl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nyocictl.h; sourceTree = "<group>"; };
+		277A054520AC959F00970354 /* nyoci-plat-net-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net-internal.h"; sourceTree = "<group>"; };
+		277A054620AC959F00970354 /* nyoci-plat-net.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-plat-net.c"; sourceTree = "<group>"; };
+		277A054720AC959F00970354 /* nyoci-plat-net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net.h"; sourceTree = "<group>"; };
+		277A055820AC959F00970354 /* nyoci-plat-tls.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-plat-tls.c"; sourceTree = "<group>"; };
+		277A055920AC959F00970354 /* nyoci-plat-tls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-tls.h"; sourceTree = "<group>"; };
+		277A056220AC959F00970354 /* main-client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "main-client.c"; sourceTree = "<group>"; };
+		277A056420AC959F00970354 /* main-server.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "main-server.c"; sourceTree = "<group>"; };
+		277A056B20AC959F00970354 /* plugtest-server.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "plugtest-server.c"; sourceTree = "<group>"; };
+		277A056C20AC959F00970354 /* plugtest-server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "plugtest-server.h"; sourceTree = "<group>"; };
+		277A056F20AC959F00970354 /* selftest.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = selftest.sh; sourceTree = "<group>"; };
+		277A057720AC959F00970354 /* test-concurrency.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "test-concurrency.c"; sourceTree = "<group>"; };
+		277A057920AC959F00970354 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
+		277A061E20AC9B0200970354 /* example-server */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "example-server"; sourceTree = BUILT_PRODUCTS_DIR; };
+		277A062E20AC9C5000970354 /* nyocictl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = nyocictl; sourceTree = BUILT_PRODUCTS_DIR; };
+		277A063F20ACAA8400970354 /* libreadline.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libreadline.tbd; path = usr/lib/libreadline.tbd; sourceTree = SDKROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		277A043420AC954900970354 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		277A061B20AC9B0200970354 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277A062920AC9B1E00970354 /* libnyoci.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		277A062B20AC9C5000970354 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277A063E20AC9C6800970354 /* libnyoci.a in Frameworks */,
+				277A064020ACAA8400970354 /* libreadline.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		277A042E20AC954900970354 = {
+			isa = PBXGroup;
+			children = (
+				277A043E20AC959E00970354 /* src */,
+				277A043820AC954900970354 /* Products */,
+				277A062820AC9B1E00970354 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 1;
+		};
+		277A043820AC954900970354 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				277A043720AC954900970354 /* libnyoci.a */,
+				277A061E20AC9B0200970354 /* example-server */,
+				277A062E20AC9C5000970354 /* nyocictl */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		277A043E20AC959E00970354 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				277A044020AC959E00970354 /* config.h */,
+				277A057920AC959F00970354 /* version.h */,
+				277A044220AC959E00970354 /* examples */,
+				277A046220AC959E00970354 /* libnyoci */,
+				277A04D620AC959F00970354 /* libnyociextra */,
+				277A04F920AC959F00970354 /* missing */,
+				277A051320AC959F00970354 /* nyocictl */,
+				277A053720AC959F00970354 /* plat-net */,
+				277A055120AC959F00970354 /* plat-tls */,
+				277A055A20AC959F00970354 /* plugtest */,
+				277A057120AC959F00970354 /* tests */,
+			);
+			name = src;
+			path = ../src;
+			sourceTree = "<group>";
+		};
+		277A044220AC959E00970354 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				277A045120AC959E00970354 /* example-1.c */,
+				277A045420AC959E00970354 /* example-2.c */,
+				277A045720AC959E00970354 /* example-3.c */,
+				277A045A20AC959E00970354 /* example-4.c */,
+				277A045D20AC959E00970354 /* example-multicast-request.c */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		277A046220AC959E00970354 /* libnyoci */ = {
+			isa = PBXGroup;
+			children = (
+				277A048A20AC959E00970354 /* btree.c */,
+				277A048C20AC959E00970354 /* coap.c */,
+				277A048E20AC959E00970354 /* fasthash.c */,
+				277A04B620AC959F00970354 /* nyoci-async.c */,
+				277A04BB20AC959F00970354 /* nyoci-dupe.c */,
+				277A04BE20AC959F00970354 /* nyoci-inbound.c */,
+				277A04C120AC959F00970354 /* nyoci-missing.c */,
+				277A04C320AC959F00970354 /* nyoci-observable.c */,
+				277A04C620AC959F00970354 /* nyoci-outbound.c */,
+				277A04C920AC959F00970354 /* nyoci-session.c */,
+				277A04CC20AC959F00970354 /* nyoci-timer.c */,
+				277A04CE20AC959F00970354 /* nyoci-transaction.c */,
+				277A04D020AC959F00970354 /* nyoci.c */,
+				277A04D220AC959F00970354 /* string-utils.c */,
+				277A04D420AC959F00970354 /* url-helpers.c */,
+				277A048920AC959E00970354 /* assert-macros.h */,
+				277A048B20AC959E00970354 /* btree.h */,
+				277A048D20AC959E00970354 /* coap.h */,
+				277A048F20AC959E00970354 /* fasthash.h */,
+				277A049020AC959E00970354 /* libnyoci.h */,
+				277A04B220AC959F00970354 /* ll.h */,
+				277A04B720AC959F00970354 /* nyoci-async.h */,
+				277A04B820AC959F00970354 /* nyoci-config.h */,
+				277A04BA20AC959F00970354 /* nyoci-defaults.h */,
+				277A04BC20AC959F00970354 /* nyoci-dupe.h */,
+				277A04BD20AC959F00970354 /* nyoci-helpers.h */,
+				277A04BF20AC959F00970354 /* nyoci-internal.h */,
+				277A04C020AC959F00970354 /* nyoci-logging.h */,
+				277A04C220AC959F00970354 /* nyoci-missing.h */,
+				277A04C420AC959F00970354 /* nyoci-observable.h */,
+				277A04C520AC959F00970354 /* nyoci-opts.h */,
+				277A04C720AC959F00970354 /* nyoci-plat-net-func.h */,
+				277A04C820AC959F00970354 /* nyoci-plat-tls-func.h */,
+				277A04CA20AC959F00970354 /* nyoci-session.h */,
+				277A04CB20AC959F00970354 /* nyoci-status.h */,
+				277A04CD20AC959F00970354 /* nyoci-timer.h */,
+				277A04CF20AC959F00970354 /* nyoci-transaction.h */,
+				277A04D320AC959F00970354 /* string-utils.h */,
+				277A04D520AC959F00970354 /* url-helpers.h */,
+			);
+			path = libnyoci;
+			sourceTree = "<group>";
+		};
+		277A04D620AC959F00970354 /* libnyociextra */ = {
+			isa = PBXGroup;
+			children = (
+				277A04EB20AC959F00970354 /* nyoci-list.c */,
+				277A04EE20AC959F00970354 /* nyoci-node-router.c */,
+				277A04F220AC959F00970354 /* nyoci-var-handler.c */,
+				277A04E420AC959F00970354 /* libnyociextra.h */,
+				277A04EF20AC959F00970354 /* nyoci-node-router.h */,
+				277A04F320AC959F00970354 /* nyoci-var-handler.h */,
+			);
+			path = libnyociextra;
+			sourceTree = "<group>";
+		};
+		277A04F920AC959F00970354 /* missing */ = {
+			isa = PBXGroup;
+			children = (
+				277A04FA20AC959F00970354 /* fgetln.h */,
+				277A04FB20AC959F00970354 /* getline.c */,
+				277A04FF20AC959F00970354 /* strlcat */,
+				277A050920AC959F00970354 /* strlcpy */,
+			);
+			path = missing;
+			sourceTree = "<group>";
+		};
+		277A04FF20AC959F00970354 /* strlcat */ = {
+			isa = PBXGroup;
+			children = (
+				277A050620AC959F00970354 /* strlcat.c */,
+				277A050720AC959F00970354 /* strlcat.h */,
+				277A050820AC959F00970354 /* strlcat_test.c */,
+			);
+			path = strlcat;
+			sourceTree = "<group>";
+		};
+		277A050920AC959F00970354 /* strlcpy */ = {
+			isa = PBXGroup;
+			children = (
+				277A051020AC959F00970354 /* strlcpy.c */,
+				277A051120AC959F00970354 /* strlcpy.h */,
+				277A051220AC959F00970354 /* strlcpy_test.c */,
+			);
+			path = strlcpy;
+			sourceTree = "<group>";
+		};
+		277A051320AC959F00970354 /* nyocictl */ = {
+			isa = PBXGroup;
+			children = (
+				277A051E20AC959F00970354 /* cmd_delete.c */,
+				277A052020AC959F00970354 /* cmd_get.c */,
+				277A052220AC959F00970354 /* cmd_list.c */,
+				277A052420AC959F00970354 /* cmd_post.c */,
+				277A052620AC959F00970354 /* cmd_repeat.c */,
+				277A052820AC959F00970354 /* help.c */,
+				277A052A20AC959F00970354 /* main.c */,
+				277A051F20AC959F00970354 /* cmd_delete.h */,
+				277A052120AC959F00970354 /* cmd_get.h */,
+				277A052320AC959F00970354 /* cmd_list.h */,
+				277A052520AC959F00970354 /* cmd_post.h */,
+				277A052720AC959F00970354 /* cmd_repeat.h */,
+				277A052920AC959F00970354 /* help.h */,
+				277A053620AC959F00970354 /* nyocictl.h */,
+			);
+			path = nyocictl;
+			sourceTree = "<group>";
+		};
+		277A053720AC959F00970354 /* plat-net */ = {
+			isa = PBXGroup;
+			children = (
+				277A053820AC959F00970354 /* posix */,
+			);
+			path = "plat-net";
+			sourceTree = "<group>";
+		};
+		277A053820AC959F00970354 /* posix */ = {
+			isa = PBXGroup;
+			children = (
+				277A054520AC959F00970354 /* nyoci-plat-net-internal.h */,
+				277A054620AC959F00970354 /* nyoci-plat-net.c */,
+				277A054720AC959F00970354 /* nyoci-plat-net.h */,
+			);
+			path = posix;
+			sourceTree = "<group>";
+		};
+		277A055120AC959F00970354 /* plat-tls */ = {
+			isa = PBXGroup;
+			children = (
+				277A055220AC959F00970354 /* openssl */,
+			);
+			path = "plat-tls";
+			sourceTree = "<group>";
+		};
+		277A055220AC959F00970354 /* openssl */ = {
+			isa = PBXGroup;
+			children = (
+				277A055820AC959F00970354 /* nyoci-plat-tls.c */,
+				277A055920AC959F00970354 /* nyoci-plat-tls.h */,
+			);
+			path = openssl;
+			sourceTree = "<group>";
+		};
+		277A055A20AC959F00970354 /* plugtest */ = {
+			isa = PBXGroup;
+			children = (
+				277A056220AC959F00970354 /* main-client.c */,
+				277A056420AC959F00970354 /* main-server.c */,
+				277A056B20AC959F00970354 /* plugtest-server.c */,
+				277A056C20AC959F00970354 /* plugtest-server.h */,
+				277A056F20AC959F00970354 /* selftest.sh */,
+			);
+			path = plugtest;
+			sourceTree = "<group>";
+		};
+		277A057120AC959F00970354 /* tests */ = {
+			isa = PBXGroup;
+			children = (
+				277A057720AC959F00970354 /* test-concurrency.c */,
+			);
+			path = tests;
+			sourceTree = "<group>";
+		};
+		277A062820AC9B1E00970354 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				277A063F20ACAA8400970354 /* libreadline.tbd */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		277A043520AC954900970354 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277A05E020AC959F00970354 /* fgetln.h in Headers */,
+				277A05B220AC959F00970354 /* nyoci-async.h in Headers */,
+				277A060720AC959F00970354 /* nyoci-plat-net.h in Headers */,
+				277A05C220AC959F00970354 /* nyoci-plat-tls-func.h in Headers */,
+				277A05F220AC959F00970354 /* cmd_post.h in Headers */,
+				277A059A20AC959F00970354 /* btree.h in Headers */,
+				277A05B920AC959F00970354 /* nyoci-internal.h in Headers */,
+				277A05F620AC959F00970354 /* help.h in Headers */,
+				277A05DD20AC959F00970354 /* nyoci-var-handler.h in Headers */,
+				277A057A20AC959F00970354 /* config.h in Headers */,
+				277A05B720AC959F00970354 /* nyoci-helpers.h in Headers */,
+				277A05EC20AC959F00970354 /* cmd_delete.h in Headers */,
+				277A05BA20AC959F00970354 /* nyoci-logging.h in Headers */,
+				277A060520AC959F00970354 /* nyoci-plat-net-internal.h in Headers */,
+				277A059E20AC959F00970354 /* fasthash.h in Headers */,
+				277A05DA20AC959F00970354 /* nyoci-node-router.h in Headers */,
+				277A05B320AC959F00970354 /* nyoci-config.h in Headers */,
+				277A05CC20AC959F00970354 /* string-utils.h in Headers */,
+				277A060E20AC959F00970354 /* nyoci-plat-tls.h in Headers */,
+				277A05D520AC959F00970354 /* libnyociextra.h in Headers */,
+				277A059F20AC959F00970354 /* libnyoci.h in Headers */,
+				277A05B620AC959F00970354 /* nyoci-dupe.h in Headers */,
+				277A05C120AC959F00970354 /* nyoci-plat-net-func.h in Headers */,
+				277A05C920AC959F00970354 /* nyoci-transaction.h in Headers */,
+				277A05AF20AC959F00970354 /* ll.h in Headers */,
+				277A05CE20AC959F00970354 /* url-helpers.h in Headers */,
+				277A05F420AC959F00970354 /* cmd_repeat.h in Headers */,
+				277A05EE20AC959F00970354 /* cmd_get.h in Headers */,
+				277A05C720AC959F00970354 /* nyoci-timer.h in Headers */,
+				277A05E920AC959F00970354 /* strlcpy.h in Headers */,
+				277A059820AC959F00970354 /* assert-macros.h in Headers */,
+				277A05E520AC959F00970354 /* strlcat.h in Headers */,
+				277A05BF20AC959F00970354 /* nyoci-opts.h in Headers */,
+				277A05BE20AC959F00970354 /* nyoci-observable.h in Headers */,
+				277A05C420AC959F00970354 /* nyoci-session.h in Headers */,
+				277A05BC20AC959F00970354 /* nyoci-missing.h in Headers */,
+				277A060020AC959F00970354 /* nyocictl.h in Headers */,
+				277A061520AC959F00970354 /* plugtest-server.h in Headers */,
+				277A061920AC959F00970354 /* version.h in Headers */,
+				277A05C520AC959F00970354 /* nyoci-status.h in Headers */,
+				277A059C20AC959F00970354 /* coap.h in Headers */,
+				277A05B420AC959F00970354 /* nyoci-defaults.h in Headers */,
+				277A05F020AC959F00970354 /* cmd_list.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		277A043620AC954900970354 /* nyoci */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 277A043B20AC954900970354 /* Build configuration list for PBXNativeTarget "nyoci" */;
+			buildPhases = (
+				277A043320AC954900970354 /* Sources */,
+				277A043420AC954900970354 /* Frameworks */,
+				277A043520AC954900970354 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = nyoci;
+			productName = nyociti;
+			productReference = 277A043720AC954900970354 /* libnyoci.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		277A061D20AC9B0200970354 /* example-server */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 277A062220AC9B0200970354 /* Build configuration list for PBXNativeTarget "example-server" */;
+			buildPhases = (
+				277A061A20AC9B0200970354 /* Sources */,
+				277A061B20AC9B0200970354 /* Frameworks */,
+				277A061C20AC9B0200970354 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				277A062720AC9B1900970354 /* PBXTargetDependency */,
+			);
+			name = "example-server";
+			productName = "example-server";
+			productReference = 277A061E20AC9B0200970354 /* example-server */;
+			productType = "com.apple.product-type.tool";
+		};
+		277A062D20AC9C5000970354 /* nyocictl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 277A063220AC9C5000970354 /* Build configuration list for PBXNativeTarget "nyocictl" */;
+			buildPhases = (
+				277A062A20AC9C5000970354 /* Sources */,
+				277A062B20AC9C5000970354 /* Frameworks */,
+				277A062C20AC9C5000970354 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				277A063D20AC9C6300970354 /* PBXTargetDependency */,
+			);
+			name = nyocictl;
+			productName = nyocictl;
+			productReference = 277A062E20AC9C5000970354 /* nyocictl */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		277A042F20AC954900970354 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = Couchbase;
+				TargetAttributes = {
+					277A043620AC954900970354 = {
+						CreatedOnToolsVersion = 9.3;
+					};
+					277A061D20AC9B0200970354 = {
+						CreatedOnToolsVersion = 9.3;
+					};
+					277A062D20AC9C5000970354 = {
+						CreatedOnToolsVersion = 9.3;
+					};
+				};
+			};
+			buildConfigurationList = 277A043220AC954900970354 /* Build configuration list for PBXProject "nyoci" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 277A042E20AC954900970354;
+			productRefGroup = 277A043820AC954900970354 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				277A043620AC954900970354 /* nyoci */,
+				277A061D20AC9B0200970354 /* example-server */,
+				277A062D20AC9C5000970354 /* nyocictl */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		277A043320AC954900970354 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277A05D720AC959F00970354 /* nyoci-list.c in Sources */,
+				277A05E120AC959F00970354 /* getline.c in Sources */,
+				277A05C020AC959F00970354 /* nyoci-outbound.c in Sources */,
+				277A060620AC959F00970354 /* nyoci-plat-net.c in Sources */,
+				277A05E420AC959F00970354 /* strlcat.c in Sources */,
+				277A05E820AC959F00970354 /* strlcpy.c in Sources */,
+				277A05C320AC959F00970354 /* nyoci-session.c in Sources */,
+				277A059B20AC959F00970354 /* coap.c in Sources */,
+				277A05C620AC959F00970354 /* nyoci-timer.c in Sources */,
+				277A05EA20AC959F00970354 /* strlcpy_test.c in Sources */,
+				277A059D20AC959F00970354 /* fasthash.c in Sources */,
+				277A05BB20AC959F00970354 /* nyoci-missing.c in Sources */,
+				277A05BD20AC959F00970354 /* nyoci-observable.c in Sources */,
+				277A05B120AC959F00970354 /* nyoci-async.c in Sources */,
+				277A05CB20AC959F00970354 /* string-utils.c in Sources */,
+				277A05B520AC959F00970354 /* nyoci-dupe.c in Sources */,
+				277A05CA20AC959F00970354 /* nyoci.c in Sources */,
+				277A05CD20AC959F00970354 /* url-helpers.c in Sources */,
+				277A05B820AC959F00970354 /* nyoci-inbound.c in Sources */,
+				277A059920AC959F00970354 /* btree.c in Sources */,
+				277A05E620AC959F00970354 /* strlcat_test.c in Sources */,
+				277A05D920AC959F00970354 /* nyoci-node-router.c in Sources */,
+				277A05C820AC959F00970354 /* nyoci-transaction.c in Sources */,
+				277A05DC20AC959F00970354 /* nyoci-var-handler.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		277A061A20AC9B0200970354 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277A062520AC9B0C00970354 /* example-2.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		277A062A20AC9C5000970354 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				277A063620AC9C5500970354 /* cmd_get.c in Sources */,
+				277A063A20AC9C5500970354 /* help.c in Sources */,
+				277A063720AC9C5500970354 /* cmd_list.c in Sources */,
+				277A063B20AC9C5500970354 /* main.c in Sources */,
+				277A063920AC9C5500970354 /* cmd_repeat.c in Sources */,
+				277A063820AC9C5500970354 /* cmd_post.c in Sources */,
+				277A063520AC9C5500970354 /* cmd_delete.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		277A062720AC9B1900970354 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 277A043620AC954900970354 /* nyoci */;
+			targetProxy = 277A062620AC9B1900970354 /* PBXContainerItemProxy */;
+		};
+		277A063D20AC9C6300970354 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 277A043620AC954900970354 /* nyoci */;
+			targetProxy = 277A063C20AC9C6300970354 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		277A043920AC954900970354 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					HAVE_CONFIG_H,
+					DEBUG,
+					VERBOSE_DEBUG,
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = ../src;
+				WARNING_CFLAGS = "-Wno-expansion-to-defined";
+			};
+			name = Debug;
+		};
+		277A043A20AC954900970354 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					HAVE_CONFIG_H,
+					NDEBUG,
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SYSTEM_HEADER_SEARCH_PATHS = ../src;
+				WARNING_CFLAGS = "-Wno-expansion-to-defined";
+			};
+			name = Release;
+		};
+		277A043C20AC954900970354 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N2Q372V7W2;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					BUILDING_LIBNYOCI,
+					"$(inherited)",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		277A043D20AC954900970354 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_DOCUMENTATION_COMMENTS = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N2Q372V7W2;
+				EXECUTABLE_PREFIX = lib;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					BUILDING_LIBNYOCI,
+					"$(inherited)",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		277A062320AC9B0200970354 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N2Q372V7W2;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		277A062420AC9B0200970354 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N2Q372V7W2;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		277A063320AC9C5000970354 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N2Q372V7W2;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		277A063420AC9C5000970354 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N2Q372V7W2;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		277A043220AC954900970354 /* Build configuration list for PBXProject "nyoci" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				277A043920AC954900970354 /* Debug */,
+				277A043A20AC954900970354 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		277A043B20AC954900970354 /* Build configuration list for PBXNativeTarget "nyoci" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				277A043C20AC954900970354 /* Debug */,
+				277A043D20AC954900970354 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		277A062220AC9B0200970354 /* Build configuration list for PBXNativeTarget "example-server" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				277A062320AC9B0200970354 /* Debug */,
+				277A062420AC9B0200970354 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		277A063220AC9C5000970354 /* Build configuration list for PBXNativeTarget "nyocictl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				277A063320AC9C5000970354 /* Debug */,
+				277A063420AC9C5000970354 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 277A042F20AC954900970354 /* Project object */;
+}

--- a/Xcode/nyoci.xcodeproj/project.pbxproj
+++ b/Xcode/nyoci.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		277A057A20AC959F00970354 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A044020AC959E00970354 /* config.h */; };
 		277A059820AC959F00970354 /* assert-macros.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A048920AC959E00970354 /* assert-macros.h */; };
 		277A059920AC959F00970354 /* btree.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A048A20AC959E00970354 /* btree.c */; };
 		277A059A20AC959F00970354 /* btree.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A048B20AC959E00970354 /* btree.h */; };
@@ -19,7 +18,6 @@
 		277A05AF20AC959F00970354 /* ll.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04B220AC959F00970354 /* ll.h */; };
 		277A05B120AC959F00970354 /* nyoci-async.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04B620AC959F00970354 /* nyoci-async.c */; };
 		277A05B220AC959F00970354 /* nyoci-async.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04B720AC959F00970354 /* nyoci-async.h */; };
-		277A05B320AC959F00970354 /* nyoci-config.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04B820AC959F00970354 /* nyoci-config.h */; };
 		277A05B420AC959F00970354 /* nyoci-defaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04BA20AC959F00970354 /* nyoci-defaults.h */; };
 		277A05B520AC959F00970354 /* nyoci-dupe.c in Sources */ = {isa = PBXBuildFile; fileRef = 277A04BB20AC959F00970354 /* nyoci-dupe.c */; };
 		277A05B620AC959F00970354 /* nyoci-dupe.h in Headers */ = {isa = PBXBuildFile; fileRef = 277A04BC20AC959F00970354 /* nyoci-dupe.h */; };
@@ -127,7 +125,6 @@
 
 /* Begin PBXFileReference section */
 		277A043720AC954900970354 /* libnyoci.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libnyoci.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		277A044020AC959E00970354 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
 		277A045120AC959E00970354 /* example-1.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-1.c"; sourceTree = "<group>"; };
 		277A045420AC959E00970354 /* example-2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-2.c"; sourceTree = "<group>"; };
 		277A045720AC959E00970354 /* example-3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "example-3.c"; sourceTree = "<group>"; };
@@ -144,7 +141,6 @@
 		277A04B220AC959F00970354 /* ll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ll.h; sourceTree = "<group>"; };
 		277A04B620AC959F00970354 /* nyoci-async.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-async.c"; sourceTree = "<group>"; };
 		277A04B720AC959F00970354 /* nyoci-async.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-async.h"; sourceTree = "<group>"; };
-		277A04B820AC959F00970354 /* nyoci-config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-config.h"; sourceTree = "<group>"; };
 		277A04BA20AC959F00970354 /* nyoci-defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-defaults.h"; sourceTree = "<group>"; };
 		277A04BB20AC959F00970354 /* nyoci-dupe.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-dupe.c"; sourceTree = "<group>"; };
 		277A04BC20AC959F00970354 /* nyoci-dupe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-dupe.h"; sourceTree = "<group>"; };
@@ -268,7 +264,6 @@
 		277A043E20AC959E00970354 /* src */ = {
 			isa = PBXGroup;
 			children = (
-				277A044020AC959E00970354 /* config.h */,
 				277A057920AC959F00970354 /* version.h */,
 				277A044220AC959E00970354 /* examples */,
 				277A046220AC959E00970354 /* libnyoci */,
@@ -321,7 +316,6 @@
 				277A049020AC959E00970354 /* libnyoci.h */,
 				277A04B220AC959F00970354 /* ll.h */,
 				277A04B720AC959F00970354 /* nyoci-async.h */,
-				277A04B820AC959F00970354 /* nyoci-config.h */,
 				277A04BA20AC959F00970354 /* nyoci-defaults.h */,
 				277A04BC20AC959F00970354 /* nyoci-dupe.h */,
 				277A04BD20AC959F00970354 /* nyoci-helpers.h */,
@@ -486,14 +480,12 @@
 				277A05B920AC959F00970354 /* nyoci-internal.h in Headers */,
 				277A05F620AC959F00970354 /* help.h in Headers */,
 				277A05DD20AC959F00970354 /* nyoci-var-handler.h in Headers */,
-				277A057A20AC959F00970354 /* config.h in Headers */,
 				277A05B720AC959F00970354 /* nyoci-helpers.h in Headers */,
 				277A05EC20AC959F00970354 /* cmd_delete.h in Headers */,
 				277A05BA20AC959F00970354 /* nyoci-logging.h in Headers */,
 				277A060520AC959F00970354 /* nyoci-plat-net-internal.h in Headers */,
 				277A059E20AC959F00970354 /* fasthash.h in Headers */,
 				277A05DA20AC959F00970354 /* nyoci-node-router.h in Headers */,
-				277A05B320AC959F00970354 /* nyoci-config.h in Headers */,
 				277A05CC20AC959F00970354 /* string-utils.h in Headers */,
 				277A060E20AC959F00970354 /* nyoci-plat-tls.h in Headers */,
 				277A05D520AC959F00970354 /* libnyociextra.h in Headers */,
@@ -733,7 +725,6 @@
 					"$(inherited)",
 					HAVE_CONFIG_H,
 					DEBUG,
-					VERBOSE_DEBUG,
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -743,6 +734,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = macOS/;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -804,6 +796,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = macOS/;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;

--- a/Xcode/nyoci.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Xcode/nyoci.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Xcode/nyoci.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Xcode/nyoci.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Xcode/nyoci.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Xcode/nyoci.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/src/libnyoci/coap.h
+++ b/src/libnyoci/coap.h
@@ -113,6 +113,8 @@
 #define COAP_EXCHANGE_LIFETIME	((COAP_ACK_TIMEOUT * ((1<<COAP_MAX_RETRANSMIT) - 1) * COAP_ACK_RANDOM_FACTOR) + (2 * COAP_MAX_LATENCY) + COAP_PROCESSING_DELAY)
 #define COAP_NON_LIFETIME		(COAP_MAX_TRANSMIT_SPAN + COAP_MAX_LATENCY)
 
+NYOCI_BEGIN_C_DECLS
+
 typedef char coap_transaction_type_t;
 typedef uint16_t coap_msg_id_t;
 typedef uint16_t coap_code_t;
@@ -401,14 +403,18 @@ struct coap_block_info_s {
 
 NYOCI_API_EXTERN void coap_decode_block(struct coap_block_info_s* block_info, uint32_t block);
 
+NYOCI_END_C_DECLS
+
 #if !CONTIKI
 #include <stdio.h>
+NYOCI_BEGIN_C_DECLS
 NYOCI_API_EXTERN void coap_dump_header(
 	FILE*			outstream,
 	const char*		prefix,
 	const struct coap_header_s* header,
 	coap_size_t packet_size
 );
+NYOCI_END_C_DECLS
 #endif
 
 /*!	@} */

--- a/src/libnyoci/nyoci-internal.h
+++ b/src/libnyoci/nyoci-internal.h
@@ -149,9 +149,9 @@ struct nyoci_s {
 //! Initializes an LibNyoci instance. Does not allocate any memory.
 NYOCI_API_EXTERN nyoci_t nyoci_init(nyoci_t self);
 
-NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_handle_request();
+NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_handle_request(void);
 
-NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_handle_response();
+NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_handle_response(void);
 
 NYOCI_INTERNAL_EXTERN nyoci_t nyoci_plat_init(nyoci_t self);
 NYOCI_INTERNAL_EXTERN void nyoci_plat_finalize(nyoci_t self);
@@ -159,6 +159,10 @@ NYOCI_INTERNAL_EXTERN void nyoci_plat_finalize(nyoci_t self);
 NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_outbound_set_var_content_int(int v);
 NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_outbound_set_var_content_unsigned_int(unsigned int v);
 NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_outbound_set_var_content_unsigned_long_int(unsigned long int v);
+
+#if NYOCI_CONF_ENABLE_VHOSTS
+NYOCI_INTERNAL_EXTERN nyoci_status_t nyoci_vhost_route(nyoci_request_handler_func* func, void** context);
+#endif
 
 
 NYOCI_END_C_DECLS

--- a/src/libnyoci/nyoci-observable.c
+++ b/src/libnyoci/nyoci-observable.c
@@ -261,7 +261,7 @@ retry_sending_event(struct nyoci_observer_s* observer)
 	);
 #endif
 
-	status = nyoci_handle_request(self);
+	status = nyoci_handle_request();
 	require(!status || status == NYOCI_STATUS_NOT_FOUND || status == NYOCI_STATUS_NOT_ALLOWED, bail);
 
 	if (status) {

--- a/src/libnyoci/nyoci-outbound.c
+++ b/src/libnyoci/nyoci-outbound.c
@@ -398,6 +398,7 @@ nyoci_outbound_set_uri(
 	NYOCI_NON_RECURSIVE char* uri_copy;
 
 	memset((void*)&components, 0, sizeof(components));
+    toport = COAP_DEFAULT_PORT;
 	uri_copy = NULL;
 
 	require_action(uri, bail, ret = NYOCI_STATUS_INVALID_ARGUMENT);

--- a/src/libnyoci/nyoci-timer.c
+++ b/src/libnyoci/nyoci-timer.c
@@ -178,7 +178,7 @@ nyoci_invalidate_timer(
 
 #if NYOCI_DEBUG_TIMERS || VERBOSE_DEBUG
 void
-nyoci_dump_all_timers(nyoci_t self) {
+static nyoci_dump_all_timers(nyoci_t self) {
 	nyoci_timer_t iter;
 
 	if (self->timers) {

--- a/src/libnyoci/nyoci-transaction.c
+++ b/src/libnyoci/nyoci-transaction.c
@@ -76,7 +76,7 @@ nyoci_transaction_compare_msg_id(
 }
 #endif
 
-nyoci_transaction_t
+static nyoci_transaction_t
 nyoci_transaction_find_via_msg_id(nyoci_t self, coap_msg_id_t msg_id) {
 	NYOCI_SINGLETON_SELF_HOOK;
 
@@ -96,7 +96,7 @@ nyoci_transaction_find_via_msg_id(nyoci_t self, coap_msg_id_t msg_id) {
 
 }
 
-nyoci_transaction_t
+static nyoci_transaction_t
 nyoci_transaction_find_via_token(nyoci_t self, coap_msg_id_t token) {
 	NYOCI_SINGLETON_SELF_HOOK;
 

--- a/src/libnyoci/nyoci.c
+++ b/src/libnyoci/nyoci.c
@@ -61,7 +61,7 @@ struct nyoci_s gNyociInstance;
 #include <pthread.h>
 static pthread_key_t nyoci_current_instance_key;
 static pthread_once_t nyoci_current_instance_once;
-void
+static void
 nyoci_current_instance_setup(void)
 {
 	pthread_key_create(&nyoci_current_instance_key, NULL);

--- a/src/libnyociextra/nyoci-node-router.c
+++ b/src/libnyociextra/nyoci-node-router.c
@@ -152,7 +152,7 @@ bail:
 // MARK: -
 // MARK: Node Funcs
 
-void
+static void
 nyoci_node_dealloc(nyoci_node_t x) {
 #if NYOCI_AVOID_MALLOC
 	x->finalize = NULL;

--- a/src/libnyociextra/nyoci-node-router.h
+++ b/src/libnyociextra/nyoci-node-router.h
@@ -130,7 +130,7 @@ NYOCI_API_EXTERN nyoci_node_t nyoci_node_get_root(nyoci_node_t node);
 NYOCI_API_EXTERN nyoci_status_t nyoci_node_router_handler(void* context);
 NYOCI_API_EXTERN nyoci_status_t nyoci_node_route(nyoci_node_t node, nyoci_request_handler_func* func, void** context);
 
-NYOCI_API_EXTERN nyoci_node_t nyoci_node_alloc();
+NYOCI_API_EXTERN nyoci_node_t nyoci_node_alloc(void);
 
 NYOCI_API_EXTERN nyoci_node_t nyoci_node_init(
 	nyoci_node_t self,

--- a/src/nyocictl/cmd_delete.c
+++ b/src/nyocictl/cmd_delete.c
@@ -110,7 +110,7 @@ bail:
 	return NYOCI_STATUS_OK;
 }
 
-nyoci_status_t
+static nyoci_status_t
 resend_delete_request(const char* url) {
 	nyoci_status_t status = 0;
 

--- a/src/nyocictl/cmd_get.c
+++ b/src/nyocictl/cmd_get.c
@@ -181,7 +181,7 @@ bail:
 	return NYOCI_STATUS_OK;
 }
 
-nyoci_status_t
+static nyoci_status_t
 resend_get_request(void* context) {
 	nyoci_status_t status = 0;
 
@@ -231,7 +231,9 @@ send_get_request(
 		flags |= NYOCI_TRANSACTION_KEEPALIVE;
 	}
 
-	nyoci_transaction_end(nyoci,&transaction);
+	if (transaction.active) {
+		nyoci_transaction_end(nyoci,&transaction);
+	}
 	nyoci_transaction_init(
 		&transaction,
 		flags, // Flags
@@ -371,7 +373,9 @@ tool_cmd_get(
 	}
 
 bail:
-	nyoci_transaction_end(nyoci,&transaction);
+	if (transaction.active) {
+		nyoci_transaction_end(nyoci,&transaction);
+	}
 	signal(SIGINT, previous_sigint_handler);
 	url_data = NULL;
 	return gRet;

--- a/src/nyocictl/cmd_list.c
+++ b/src/nyocictl/cmd_list.c
@@ -69,7 +69,7 @@ static char* list_data;
 static coap_size_t list_data_size;
 static struct nyoci_transaction_s transaction;
 
-void
+static void
 parse_link_format(char* content, coap_size_t content_length, void* context) {
 	char *iter = content;
 	char *end = content + content_length;
@@ -453,7 +453,7 @@ tool_cmd_list(
 	HANDLE_LONG_ARGUMENT("follow") redirect_count = 10;
 	HANDLE_LONG_ARGUMENT("slice-size") size_request =
 		htons(strtol(argv[++i], NULL, 0));
-	HANDLE_LONG_ARGUMENT("timeout") timeout_cms = strtol(argv[++i], NULL, 0);
+	HANDLE_LONG_ARGUMENT("timeout") timeout_cms = (int)strtol(argv[++i], NULL, 0);
 	HANDLE_LONG_ARGUMENT("filename-only") list_filename_only = true;
 
 	HANDLE_LONG_ARGUMENT("help") {
@@ -464,7 +464,7 @@ tool_cmd_list(
 	BEGIN_SHORT_ARGUMENTS(gRet)
 	HANDLE_SHORT_ARGUMENT('i') list_show_headers = true;
 	HANDLE_SHORT_ARGUMENT('f') redirect_count = 10;
-	HANDLE_SHORT_ARGUMENT('t') timeout_cms = strtol(argv[++i], NULL, 0);
+	HANDLE_SHORT_ARGUMENT('t') timeout_cms = (int)strtol(argv[++i], NULL, 0);
 
 	HANDLE_SHORT_ARGUMENT2('h', '?') {
 		print_arg_list_help(option_list, argv[0], "[args] <uri>");

--- a/src/nyocictl/cmd_post.c
+++ b/src/nyocictl/cmd_post.c
@@ -125,7 +125,7 @@ bail:
 }
 
 
-nyoci_status_t
+static nyoci_status_t
 resend_post_request(struct post_request_s *request) {
 	nyoci_status_t status = 0;
 
@@ -216,7 +216,7 @@ tool_cmd_post(
 
 	BEGIN_LONG_ARGUMENTS(gRet)
 	HANDLE_LONG_ARGUMENT("include") post_show_headers = true;
-	HANDLE_LONG_ARGUMENT("outbound-slice-size") outbound_slice_size = strtol(argv[++i], NULL, 0);
+	HANDLE_LONG_ARGUMENT("outbound-slice-size") outbound_slice_size = (int)strtol(argv[++i], NULL, 0);
 	HANDLE_LONG_ARGUMENT("content-type") content_type = coap_content_type_from_cstr(argv[++i]);
 	HANDLE_LONG_ARGUMENT("content-format") content_type = coap_content_type_from_cstr(argv[++i]);
 	HANDLE_LONG_ARGUMENT("non") post_tt = COAP_TRANS_TYPE_NONCONFIRMABLE;

--- a/src/nyocictl/cmd_repeat.c
+++ b/src/nyocictl/cmd_repeat.c
@@ -58,8 +58,8 @@ tool_cmd_repeat(
 	previous_sigint_handler = signal(SIGINT, &signal_interrupt);
 
 	BEGIN_LONG_ARGUMENTS(ret)
-	HANDLE_LONG_ARGUMENT("interval") interval = strtol(argv[++i], NULL, 0);
-	HANDLE_LONG_ARGUMENT("count") count = strtol(argv[++i], NULL, 0);
+	HANDLE_LONG_ARGUMENT("interval") interval = (int)strtol(argv[++i], NULL, 0);
+	HANDLE_LONG_ARGUMENT("count") count = (int)strtol(argv[++i], NULL, 0);
 	HANDLE_LONG_ARGUMENT("prefix") prefix_string = argv[++i];
 
 	HANDLE_LONG_ARGUMENT("help") {
@@ -68,8 +68,8 @@ tool_cmd_repeat(
 		goto bail;
 	}
 	BEGIN_SHORT_ARGUMENTS(ret)
-	HANDLE_SHORT_ARGUMENT('i') interval = strtol(argv[++i], NULL, 0);
-	HANDLE_SHORT_ARGUMENT('c') count = strtol(argv[++i], NULL, 0);
+	HANDLE_SHORT_ARGUMENT('i') interval = (int)strtol(argv[++i], NULL, 0);
+	HANDLE_SHORT_ARGUMENT('c') count = (int)strtol(argv[++i], NULL, 0);
 
 	HANDLE_SHORT_ARGUMENT2('h', '?') {
 		print_arg_list_help(option_list, argv[0], "[args] command [...]");

--- a/src/nyocictl/main.c
+++ b/src/nyocictl/main.c
@@ -69,7 +69,7 @@ static arg_list_item_t option_list[] = {
 	{ 0 }
 };
 
-void print_commands();
+void print_commands(void);
 
 static int
 tool_cmd_help(
@@ -300,7 +300,7 @@ bail:
 static bool history_disabled;
 #endif
 
-void process_input_line(char *l) {
+static void process_input_line(char *l) {
 	char *inputstring;
 	char *argv2[100];
 	char **ap = argv2;
@@ -355,7 +355,7 @@ static char* get_current_prompt() {
 	return prompt;
 }
 
-void process_input_readline(char *l) {
+static void process_input_readline(char *l) {
 	process_input_line(l);
 	if(istty) {
 #if HAVE_RL_SET_PROMPT
@@ -372,12 +372,13 @@ void process_input_readline(char *l) {
 
 #if HAVE_LIBREADLINE
 
-char *
+static char *
 nyoci_command_generator(
 	const char *text,
 	int state
 ) {
-	static int list_index, len;
+	static int list_index;
+	static size_t len;
 	const char *name;
 
 	/* If this is a new word to complete, initialize now.  This includes
@@ -402,7 +403,7 @@ nyoci_command_generator(
 	return ((char *)NULL);
 }
 
-char *
+static char *
 nyoci_directory_generator(
 	const char *text,
 	int state
@@ -425,7 +426,7 @@ nyoci_directory_generator(
 	 variable to 0. */
 	if (!state)
 	{
-		int i;
+		size_t i;
 
 		if(temp_file)
 			fclose(temp_file);
@@ -534,7 +535,7 @@ bail:
 	return ret;
 }
 
-char **
+static char **
 nyoci_attempted_completion (
 	const char *text,
 	int start,
@@ -598,7 +599,7 @@ bail:
 #define PACKAGE_VERSION "0.0"
 #endif
 
-void
+static void
 print_version() {
 	printf(PACKAGE_TARNAME"ctl "PACKAGE_VERSION"\n");
 }
@@ -612,8 +613,10 @@ main(
 ) {
 	int i, debug_mode = 0;
 	uint16_t port = 61616;
+#if NYOCI_DTLS
 	uint16_t ssl_port = 61617;
 	int ssl_ret;
+#endif
 
 #if NYOCI_DTLS
 #if NYOCI_PLAT_TLS_OPENSSL && HAVE_OPENSSL_SSL_CONF_CTX_NEW
@@ -665,7 +668,7 @@ main(
 #endif
 #endif
 
-	srandom(time(NULL));
+	srandom((unsigned)time(NULL));
 
 	BEGIN_LONG_ARGUMENTS(gRet)
 #if NYOCI_PLAT_TLS_OPENSSL && HAVE_OPENSSL_SSL_CONF_CTX_NEW

--- a/src/plat-net/posix/nyoci-plat-net.c
+++ b/src/plat-net/posix/nyoci-plat-net.c
@@ -105,7 +105,7 @@ typedef struct multicast_group{
 	} group;
 } multicast_group_s;
 
-void fill_multicast_group(multicast_group_s * group, const struct sockaddr* addr, int interfaceIndex)
+static void fill_multicast_group(multicast_group_s * group, const struct sockaddr* addr, int interfaceIndex)
 {
 	bzero(group, sizeof(multicast_group_s));
 
@@ -146,7 +146,7 @@ nyoci_internal_multicast_joinleave(nyoci_t self, const nyoci_sockaddr_t *group, 
 								? (join ? IP_ADD_MEMBERSHIP		: IP_DROP_MEMBERSHIP)
 								: (join ? IPV6_JOIN_GROUP		: IPV6_LEAVE_GROUP);
 
-		ret = setsockopt(fd, level, opt, &multicast.group, multicast.group_size);
+		ret = setsockopt(fd, level, opt, &multicast.group, (socklen_t)multicast.group_size);
 
 		if (ret >= 0) {
 			status = NYOCI_STATUS_OK;
@@ -206,6 +206,9 @@ nyoci_plat_join_standard_groups(nyoci_t self, int interface)
 
 #if NYOCI_PLAT_NET_POSIX_FAMILY == AF_INET6
 	ret = nyoci_internal_join_multicast_group(self, COAP_MULTICAST_IP6_LL_ALLDEVICES, interface);
+	if (ret != NYOCI_STATUS_OK) {
+		return ret;
+	}
 #endif
 
 	ret = nyoci_internal_join_multicast_group(self, COAP_MULTICAST_IP4_ALLDEVICES, interface);
@@ -986,7 +989,7 @@ nyoci_plat_lookup_hostname(const char* hostname, nyoci_sockaddr_t* saddr, int fl
 	if(error && (inet_addr(hostname) != INADDR_NONE)) {
 		char addr_v4mapped_str[8 + strlen(hostname)];
 		hint.ai_family = AF_INET6;
-		hint.ai_flags = AI_ALL | AI_V4MAPPED,
+		hint.ai_flags = AI_ALL | AI_V4MAPPED;
 		strcpy(addr_v4mapped_str,"::ffff:");
 		strcat(addr_v4mapped_str,hostname);
 		error = getaddrinfo(addr_v4mapped_str,

--- a/src/plugtest/plugtest-server.c
+++ b/src/plugtest/plugtest-server.c
@@ -90,7 +90,7 @@ plugtest_test_handler(nyoci_node_t node)
 			strlcat(content,coap_option_key_to_cstr(key,1),max_len);
 			strlcat(content,": ",max_len);
 			if(coap_option_value_is_string(key)) {
-				int argh = strlen(content)+value_len;
+				coap_size_t argh = strlen(content)+value_len;
 				strlcat(content,(char*)value,MIN(max_len,argh+1));
 				content[argh] = 0;
 			} else {

--- a/src/tests/test-concurrency.c
+++ b/src/tests/test-concurrency.c
@@ -68,7 +68,7 @@ request_handler(void* context) {
 nyoci_status_t
 test_concurrency_thread_resend(void* context)
 {
-	struct test_concurrency_thread_s* obj = (struct test_concurrency_thread_s*)context;
+//	struct test_concurrency_thread_s* obj = (struct test_concurrency_thread_s*)context;
 	nyoci_status_t status = 0;
 
 	status = nyoci_outbound_begin(


### PR DESCRIPTION
Warnings:
* Non-prototypes: changed foo(); to foo(void);
* Added a few missing prototypes
* Added “static” for internal fns not used outside their source file
* Added explicit integer downcasts, upgraded a few ints to size_t
* Commented out an unused variable
* Fixed unchecked error status in nyoci_plat_join_standard_groups()
* Fixed runtime warnings, when ending transactions in nyocictl

Bug-fix:
* Variable `toport` was used uninitialized in some code paths in nyoci_outbound_set_uri() [Fixes #2]

Added an Xcode project (in a subdirectory). Currently builds for macOS, but it'd be easy to add iOS support.