### PR TITLE
Fixed two compile errors building for ESP32

### DIFF
--- a/src/libnyoci/btree.h
+++ b/src/libnyoci/btree.h
@@ -39,7 +39,7 @@
 #include <stdio.h>      // For ssize_t
 
 #if defined(__cplusplus)
-NYOCI_INTERNAL_EXTERN "C" {
+extern "C" {
 #endif
 
 /*!	@defgroup btree Binary Tree Functions

--- a/src/libnyoci/coap.c
+++ b/src/libnyoci/coap.c
@@ -887,10 +887,10 @@ coap_dump_header(
 		if(option_ptr && option_ptr[0]==0xFF) {
 
 			fputs(prefix, outstream);
-			fprintf(outstream, "Payload-Size: %ld\n",packet_size-(option_ptr-(uint8_t*)header)-1);
+			fprintf(outstream, "Payload-Size: %zd\n",packet_size-(option_ptr-(uint8_t*)header)-1);
 		} else {
 			fputs(prefix, outstream);
-			fprintf(outstream,"PACKET CORRUPTED: %ld extra bytes\n",packet_size-(option_ptr-(uint8_t*)header));
+			fprintf(outstream,"PACKET CORRUPTED: %zd extra bytes\n",packet_size-(option_ptr-(uint8_t*)header));
 		}
 	}
 


### PR DESCRIPTION
* `NYOCI_INTERNAL_EXTERN "C"` isn't valid because `NYOCI_INTERNAL_EXTERN` doesn't always expand to `extern`. Changed to explicit `extern`.
* Two more printf format type warnings: changed from `%ld` to `%zd` since the argument type is `size_t`.