### PR TITLE
SECURITY: Address issues discovered by fuzzing

### DIFF
--- a/src/libnyoci/libnyoci.h
+++ b/src/libnyoci/libnyoci.h
@@ -91,7 +91,7 @@ NYOCI_BEGIN_C_DECLS
 #define NYOCI_LIBRARY_VERSION_CHECK()	do { } while(0)
 #else
 #ifndef ___NYOCI_CONFIG_ID
-#define ___NYOCI_CONFIG_ID 0
+#define ___NYOCI_CONFIG_ID 1
 #endif
 NYOCI_API_EXTERN void ___nyoci_check_version(uint32_t x);
 #define NYOCI_LIBRARY_VERSION_CHECK()	___nyoci_check_version(___NYOCI_CONFIG_ID)
@@ -392,7 +392,7 @@ NYOCI_API_EXTERN bool nyoci_inbound_option_strequal(coap_option_key_t key, const
 #define NYOCI_GET_PATH_INCLUDE_QUERY		(1<<2)
 
 //!	Get a string representation of the destination path in the inbound packet.
-NYOCI_API_EXTERN char* nyoci_inbound_get_path(char* where, uint8_t flags);
+NYOCI_API_EXTERN char* nyoci_inbound_get_path(char* where, coap_size_t maxlen, uint8_t flags);
 
 /*!	@} */
 

--- a/src/libnyoci/nyoci-outbound.c
+++ b/src/libnyoci/nyoci-outbound.c
@@ -612,10 +612,16 @@ nyoci_outbound_get_content_ptr(coap_size_t* max_len)
 }
 
 nyoci_status_t
-nyoci_outbound_set_content_len(coap_size_t len)
+nyoci_outbound_set_content_len(coap_size_t content_len)
 {
-	nyoci_get_current_instance()->outbound.content_len = len;
-	return NYOCI_STATUS_OK;
+	nyoci_status_t ret = NYOCI_STATUS_MESSAGE_TOO_BIG;
+	nyoci_t const self = nyoci_get_current_instance();
+	const coap_size_t header_len = (coap_size_t)(self->outbound.content_ptr-(char*)self->outbound.packet);
+	require(header_len+content_len <= self->outbound.max_packet_len, bail);
+	self->outbound.content_len = content_len;
+	ret = NYOCI_STATUS_OK;
+bail:
+	return ret;
 }
 
 

--- a/src/libnyoci/nyoci-outbound.c
+++ b/src/libnyoci/nyoci-outbound.c
@@ -303,10 +303,10 @@ nyoci_outbound_add_options_up_to_key_(
 	(void)self;
 
 #if NYOCI_CONF_TRANS_ENABLE_BLOCK2
-	if(	(self->current_transaction
-		&& self->current_transaction->next_block2)
-		&& self->outbound.last_option_key<COAP_OPTION_BLOCK2
-		&& key>COAP_OPTION_BLOCK2
+	if ( (self->current_transaction != NULL)
+	  && (self->current_transaction->next_block2 != 0)
+	  && (self->outbound.last_option_key < COAP_OPTION_BLOCK2)
+	  && (key > COAP_OPTION_BLOCK2)
 	) {
 		uint32_t block2 = htonl(self->current_transaction->next_block2);
 		uint8_t size = nyoci_calc_uint32_option_size(block2);
@@ -319,11 +319,14 @@ nyoci_outbound_add_options_up_to_key_(
 #endif
 
 #if NYOCI_CONF_TRANS_ENABLE_OBSERVING
-	if(	(self->current_transaction && self->current_transaction->flags&NYOCI_TRANSACTION_OBSERVE)
-		&& self->outbound.last_option_key<COAP_OPTION_OBSERVE
-		&& key>COAP_OPTION_OBSERVE
+	if ( (self->current_transaction != NULL)
+	  && (self->current_transaction->flags & NYOCI_TRANSACTION_OBSERVE == NYOCI_TRANSACTION_OBSERVE)
+	  && (self->outbound.last_option_key < COAP_OPTION_OBSERVE)
+	  && (key > COAP_OPTION_OBSERVE)
 	) {
-		if(self->outbound.packet->code && self->outbound.packet->code<COAP_RESULT_100) {
+		if ( (self->outbound.packet->code != 0)
+		  && (self->outbound.packet->code < COAP_RESULT_100)
+		) {
 			// For sending a request.
 			ret = nyoci_outbound_add_option_(
 				COAP_OPTION_OBSERVE,
@@ -335,9 +338,9 @@ nyoci_outbound_add_options_up_to_key_(
 #endif
 
 #if NYOCI_USE_CASCADE_COUNT
-	if(	self->outbound.last_option_key<COAP_OPTION_CASCADE_COUNT
-		&& key>COAP_OPTION_CASCADE_COUNT
-		&& self->cascade_count
+	if ( self->outbound.last_option_key < COAP_OPTION_CASCADE_COUNT
+	  && key > COAP_OPTION_CASCADE_COUNT
+	  && self->cascade_count != 0
 	) {
 		uint8_t cc = self->cascade_count-1;
 		ret = nyoci_outbound_add_option_(
@@ -362,8 +365,8 @@ nyoci_outbound_add_option(
 
 #if NYOCI_CONF_TRANS_ENABLE_BLOCK2
 	if ( key == COAP_OPTION_BLOCK2
-	  && nyoci_get_current_instance()->current_transaction
-	  && nyoci_get_current_instance()->current_transaction->next_block2
+	  && nyoci_get_current_instance()->current_transaction != NULL
+	  && nyoci_get_current_instance()->current_transaction->next_block2 != 0
 	) {
 		goto bail;
 	}

--- a/src/libnyociextra/nyoci-list.c
+++ b/src/libnyociextra/nyoci-list.c
@@ -83,9 +83,12 @@ nyoci_node_list_request_handler(
 	}
 
 	if (nyoci_inbound_option_strequal_const(COAP_OPTION_URI_PATH,"")) {
+		if (prefix != NULL && prefix[0] != 0) {
+			prefix = NULL;
+		}
+
 		// Eat the trailing '/'.
 		nyoci_inbound_next_option(NULL, NULL);
-		if(prefix[0]) prefix = NULL;
 	}
 
 	// Check over the headers to make sure they are sane.

--- a/src/plugtest/plugtest-server.c
+++ b/src/plugtest/plugtest-server.c
@@ -77,7 +77,8 @@ plugtest_test_handler(nyoci_node_t node)
 		goto bail;
 	}
 
-	nyoci_inbound_get_path(content, NYOCI_GET_PATH_LEADING_SLASH|NYOCI_GET_PATH_INCLUDE_QUERY);
+	nyoci_inbound_get_path(content, max_len, NYOCI_GET_PATH_LEADING_SLASH|NYOCI_GET_PATH_INCLUDE_QUERY);
+	assert(strlen(content)<=max_len);
 	strlcat(content,"\nPlugtest!\nMethod = ",max_len);
 	strlcat(content,coap_code_to_cstr(method),max_len);
 	strlcat(content,"\n",max_len);
@@ -100,6 +101,7 @@ plugtest_test_handler(nyoci_node_t node)
 		}
 	}
 
+	assert(strlen(content)<=max_len);
 	nyoci_outbound_set_content_len((coap_size_t)strlen(content));
 
 	ret = nyoci_outbound_send();

--- a/src/plugtest/plugtest-server.c
+++ b/src/plugtest/plugtest-server.c
@@ -297,8 +297,10 @@ plugtest_large_handler(
 			if(key == COAP_OPTION_BLOCK2) {
 				uint8_t i;
 				block_option = 0;
-				for(i = 0; i < value_len; i++)
+				require_action(value_len<=3,bail,ret=NYOCI_STATUS_INVALID_ARGUMENT);
+				for(i = 0; i < value_len; i++) {
 					block_option = (block_option << 8) + value[i];
+				}
 			}
 		}
 	}
@@ -322,12 +324,13 @@ plugtest_large_handler(
 		block_start = block_info.block_offset;
 		block_stop = block_info.block_offset + block_info.block_size;
 
-		if(max_len<(block_stop-block_start) && block_option!=0 && !block_info.block_offset) {
+		if(max_len<(block_stop-block_start) && ((block_option&0x7)!=0) && !block_info.block_offset) {
 			block_option--;
 			block_stop = 0;
 			continue;
 		}
-	} while(0==block_stop);
+		break;
+	} while(true);
 
 	require_action(block_start<resource_length,bail,ret=NYOCI_STATUS_INVALID_ARGUMENT);
 


### PR DESCRIPTION
Bruno Menlo was doing some independent security research and discovered several reproducible crashes and one hang on the `nyoci-plugtest-server` program. One of the bugs was a buffer overflow due to the misuse of the `nyoci_inbound_get_path()` API by `nyoci-plugtest-server`, which is likely exploitable.

These changes address these bugs. However, I've determined that it is way too easy to misuse the `nyoci_inbound_get_path()` API, so I have changed it to include a `maxlen` parameter. Since this is an API change, I've incremented the configuration index. Any program which uses the `NYOCI_LIBRARY_VERSION_CHECK()` or `nyoci_inbound_get_path()` will need to be recompiled after this change.

Thanks Bruno for reporting this!