### PR TITLE
Compatibility with lwIP and ESP-IDF

### DIFF
--- a/Xcode/nyoci.xcodeproj/project.pbxproj
+++ b/Xcode/nyoci.xcodeproj/project.pbxproj
@@ -196,9 +196,9 @@
 		277A052920AC959F00970354 /* help.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = help.h; sourceTree = "<group>"; };
 		277A052A20AC959F00970354 /* main.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		277A053620AC959F00970354 /* nyocictl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nyocictl.h; sourceTree = "<group>"; };
-		277A054520AC959F00970354 /* nyoci-plat-net-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net-internal.h"; sourceTree = "<group>"; };
-		277A054620AC959F00970354 /* nyoci-plat-net.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-plat-net.c"; sourceTree = "<group>"; };
-		277A054720AC959F00970354 /* nyoci-plat-net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net.h"; sourceTree = "<group>"; };
+		277A054520AC959F00970354 /* nyoci-plat-net-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net-internal.h"; sourceTree = "<group>"; usesTabs = 0; };
+		277A054620AC959F00970354 /* nyoci-plat-net.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-plat-net.c"; sourceTree = "<group>"; usesTabs = 0; };
+		277A054720AC959F00970354 /* nyoci-plat-net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-net.h"; sourceTree = "<group>"; usesTabs = 0; };
 		277A055820AC959F00970354 /* nyoci-plat-tls.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nyoci-plat-tls.c"; sourceTree = "<group>"; };
 		277A055920AC959F00970354 /* nyoci-plat-tls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nyoci-plat-tls.h"; sourceTree = "<group>"; };
 		277A056220AC959F00970354 /* main-client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "main-client.c"; sourceTree = "<group>"; };

--- a/src/libnyoci/assert-macros.h
+++ b/src/libnyoci/assert-macros.h
@@ -62,6 +62,7 @@
 #if !DEBUG || ASSERT_MACROS_SQUELCH
  #define assert_printf(fmt, ...) do { } while(0)
  #define check_string(c, s)   do { } while(0)
+ #define check_string_errno(c, s)   do { } while(0)
  #define require_action_string(c, l, a, s) \
 	do { if(!(c)) { \
 			 a; goto l; \
@@ -77,6 +78,12 @@
   #define assert_printf(fmt, ...) \
 	fprintf_P(assert_error_stream, \
 				PSTR(__FILE__ ":%d: "fmt"\n"), \
+				__LINE__, \
+				__VA_ARGS__)
+ #elif ESP_PLATFORM
+  #define assert_printf(fmt, ...) \
+    ESP_LOGE("nyoci", \
+				__FILE__ ":%d: "fmt"\n", \
 				__LINE__, \
 				__VA_ARGS__)
  #else
@@ -102,6 +109,9 @@
  #define check_string(c, s) \
    do { if(!(c)) assert_printf("Check Failed (%s)", \
 			s); } while(0)
+ #define check_string_errno(c, s) \
+   do { if(!(c)) assert_printf("Check Failed (%s), errno=%d", \
+			s, errno); } while(0)
  #define require_action_string(c, l, a, s) \
 	do { if(!(c)) { \
 		assert_printf("Requirement Failed (%s)", \
@@ -122,6 +132,7 @@
 #endif
 
  #define check(c)   check_string(c, # c)
+ #define check_errno(c)   check_string_errno(c, # c)
  #define check_noerr(c)   check((c) == 0)
  #define check_noerr_string(c, s)   check_string((c) == 0, s)
  #define require_quiet(c, l)   do { if(!(c)) goto l; } while(0)

--- a/src/libnyoci/nyoci-internal.h
+++ b/src/libnyoci/nyoci-internal.h
@@ -50,6 +50,10 @@
 		((uint32_t)random_rand() ^ \
 			((uint32_t)random_rand() << 16))
 #define NYOCI_RANDOM_MAX			RAND_MAX
+#elif ESP_PLATFORM
+#include <sodium/randombytes.h>
+#define NYOCI_FUNC_RANDOM_UINT32()   randombytes_random()
+#define NYOCI_RANDOM_MAX			(uint32_t)(0xFFFFFFFF)
 #else
 #define NYOCI_FUNC_RANDOM_UINT32() \
 		((uint32_t)random() ^ \

--- a/src/libnyoci/nyoci-logging.h
+++ b/src/libnyoci/nyoci-logging.h
@@ -34,40 +34,46 @@
 
 #if !VERBOSE_DEBUG
 
-#define CSTR(x)     (x)
+	#define CSTR(x)     (x)
 
-#ifndef DEBUG_PRINTF
-#define DEBUG_PRINTF(...)   do { } while(0)
-#endif
-#define NYOCI_DEBUG_OUT_FILE     stdout
+	#ifndef DEBUG_PRINTF
+	#define DEBUG_PRINTF(...)   do { } while(0)
+	#endif
+	#define NYOCI_DEBUG_OUT_FILE     stdout
 
 #elif defined(__AVR__)
-#define NYOCI_DEBUG_OUT_FILE     stdout
+	#define NYOCI_DEBUG_OUT_FILE     stdout
 
-#include <stdio.h>
-#include <avr/pgmspace.h>
-#define CSTR(x)     PSTR(x)
-#define DEBUG_PRINTF(...) \
+	#include <stdio.h>
+	#include <avr/pgmspace.h>
+	#define CSTR(x)     PSTR(x)
+	#define DEBUG_PRINTF(...) \
 	do { fprintf_P(NYOCI_DEBUG_OUT_FILE, __VA_ARGS__); fputc( \
-			'\n', \
-			NYOCI_DEBUG_OUT_FILE); } while(0)
+				'\n', \
+				NYOCI_DEBUG_OUT_FILE); } while(0)
 
-#else // __AVR__
-#define NYOCI_DEBUG_OUT_FILE     stderr
+#elif defined(ESP_PLATFORM)
+	#include <esp_log.h>
+	#define DEBUG_PRINTF(FMT, ...)   ESP_LOGI("nyoci", FMT, ##__VA_ARGS__)
+	#define NYOCI_DEBUG_OUT_FILE     stderr
+	#define CSTR(x)     x
 
-#include <stdio.h>
-#define CSTR(x)     (x)
-#if ASSERT_MACROS_USES_SYSLOG
-#include <syslog.h>
-#define DEBUG_PRINTF(...) syslog(7, __VA_ARGS__)
-#elif ASSERT_MACROS_USE_VANILLA_PRINTF
-#define DEBUG_PRINTF(...) \
-	do { printf(__VA_ARGS__); printf("\n"); } while(0)
 #else
-#define DEBUG_PRINTF(...) \
-	do { fprintf(NYOCI_DEBUG_OUT_FILE, __VA_ARGS__); fputc('\n', \
-			NYOCI_DEBUG_OUT_FILE); } while(0)
-#endif
+	#define NYOCI_DEBUG_OUT_FILE     stderr
+
+	#include <stdio.h>
+	#define CSTR(x)     (x)
+	#if ASSERT_MACROS_USES_SYSLOG
+		#include <syslog.h>
+		#define DEBUG_PRINTF(...) syslog(7, __VA_ARGS__)
+	#elif ASSERT_MACROS_USE_VANILLA_PRINTF
+		#define DEBUG_PRINTF(...) \
+			do { printf(__VA_ARGS__); printf("\n"); } while(0)
+	#else
+		#define DEBUG_PRINTF(...) \
+			do { fprintf(NYOCI_DEBUG_OUT_FILE, __VA_ARGS__); fputc('\n', \
+					NYOCI_DEBUG_OUT_FILE); } while(0)
+	#endif
 
 #endif
 

--- a/src/libnyoci/nyoci-outbound.c
+++ b/src/libnyoci/nyoci-outbound.c
@@ -320,7 +320,7 @@ nyoci_outbound_add_options_up_to_key_(
 
 #if NYOCI_CONF_TRANS_ENABLE_OBSERVING
 	if ( (self->current_transaction != NULL)
-	  && (self->current_transaction->flags & NYOCI_TRANSACTION_OBSERVE == NYOCI_TRANSACTION_OBSERVE)
+	  && ((self->current_transaction->flags & NYOCI_TRANSACTION_OBSERVE) == NYOCI_TRANSACTION_OBSERVE)
 	  && (self->outbound.last_option_key < COAP_OPTION_OBSERVE)
 	  && (key > COAP_OPTION_OBSERVE)
 	) {

--- a/src/plat-net/posix/nyoci-plat-net.h
+++ b/src/plat-net/posix/nyoci-plat-net.h
@@ -40,7 +40,12 @@
 #include <arpa/inet.h>
 #include <sys/errno.h>
 #include <sys/types.h>
+
+#ifdef ESP_PLATFORM
+#include <sys/socket.h>
+#else
 #include <sys/select.h>
+#endif
 
 #if NYOCI_SINGLETON
 #define nyoci_plat_update_fdsets(self,...)		nyoci_plat_update_fdsets(__VA_ARGS__)


### PR DESCRIPTION
lwIP = Lightweight IP library
<http://savannah.nongnu.org/projects/lwip/>

ESP-IDF = iOT Development Framework for Espressif's ESP32 chip
<https://github.com/espressif/esp-idf>

New preprocessor flags for configuration:
* NYOCI_LWIP -- define if compiling for lwIP. Will be automatically
  defined if ESP_PLATFORM is defined (i.e. building for ESP-IDF.)
* NYOCI_CAN_POLL -- Indicates the `poll` system call is available and
  should be used instead of `select`. Defaults to 1 unless building
  for lwIP; explicitly define it as 0 to force use of `select`.
* NYOCI_CAN_SENDMSG -- Indicates the `sendmsg` system call is
  available and should be used instead of `send`. Defaults to 1 unless
  building for lwIP; explicitly define it as 0 to force use of `send`.
  Note: `send` does not support setting the “from” address of the
  packet.

Fixes #8

(I also added a one-line commit that fixes a recent regression on the master branch
that I discovered when rebasing just now.)