### PR TITLE
Fixed a logic error due to missing parens

### DIFF
--- a/src/libnyoci/nyoci-outbound.c
+++ b/src/libnyoci/nyoci-outbound.c
@@ -320,7 +320,7 @@ nyoci_outbound_add_options_up_to_key_(
 
 #if NYOCI_CONF_TRANS_ENABLE_OBSERVING
 	if ( (self->current_transaction != NULL)
-	  && (self->current_transaction->flags & NYOCI_TRANSACTION_OBSERVE == NYOCI_TRANSACTION_OBSERVE)
+	  && ((self->current_transaction->flags & NYOCI_TRANSACTION_OBSERVE) == NYOCI_TRANSACTION_OBSERVE)
 	  && (self->outbound.last_option_key < COAP_OPTION_OBSERVE)
 	  && (key > COAP_OPTION_OBSERVE)
 	) {


### PR DESCRIPTION
`==` has higher precedence than `&`, so the expression wasn’t doing what was intended.

This was caught by GCC's `-Wparentheses`:
```
libnyoci/src/libnyoci/nyoci-outbound.c:323:41: error: suggest parentheses around comparison in operand of '&' [-Werror=parentheses]
    && (self->current_transaction->flags & NYOCI_TRANSACTION_OBSERVE == NYOCI_TRANSACTION_OBSERVE)
                                         ^
```