### PR TITLE
Bugfix/dtls memleak

### DIFF
--- a/src/libnyoci/nyoci-plat-tls-func.h
+++ b/src/libnyoci/nyoci-plat-tls-func.h
@@ -114,4 +114,8 @@ NYOCI_API_EXTERN nyoci_status_t nyoci_plat_tls_outbound_packet_process(
 	int data_len
 );
 
+NYOCI_API_EXTERN bool nyoci_plat_tls_finalize(
+	nyoci_t self
+);
+
 #endif // NYOCI_nyoci_plat_tls_h

--- a/src/libnyoci/nyoci.c
+++ b/src/libnyoci/nyoci.c
@@ -157,6 +157,10 @@ nyoci_release(nyoci_t self) {
 		nyoci_invalidate_timer(self, timer);
 	}
 
+#if NYOCI_DTLS
+	nyoci_plat_tls_finalize(self);
+#endif
+
 	nyoci_plat_finalize(self);
 
 #if !NYOCI_SINGLETON

--- a/src/plat-net/posix/nyoci-plat-net.c
+++ b/src/plat-net/posix/nyoci-plat-net.c
@@ -580,7 +580,7 @@ sendtofrom(
 		check(ret>0);
 	} else {
 		struct iovec iov = { (void *)data, len };
-		uint8_t cmbuf[CMSG_SPACE(sizeof (struct in6_pktinfo))];
+		uint8_t cmbuf[CMSG_SPACE(sizeof (struct in6_pktinfo))] = {0};
 		struct cmsghdr *scmsgp;
 		struct msghdr msg = {
 			.msg_name = (void*)saddr_to,
@@ -868,7 +868,7 @@ nyoci_plat_process(
 				nyoci_sockaddr_t remote_saddr = {};
 				nyoci_sockaddr_t local_saddr = {};
 				ssize_t packet_len = 0;
-				char cmbuf[0x100];
+				char cmbuf[0x100] = {0};
 				struct iovec iov = { packet, NYOCI_MAX_PACKET_LENGTH };
 				struct msghdr msg = {
 					.msg_name = &remote_saddr,

--- a/src/plat-tls/openssl/nyoci-plat-tls.c
+++ b/src/plat-tls/openssl/nyoci-plat-tls.c
@@ -1044,3 +1044,25 @@ bail:
 
 	return ret;
 }
+
+bool
+nyoci_plat_tls_finalize(
+	nyoci_t self
+) {
+	// Remove all sessions
+	while(self->plat.ssl.sessions) {
+		bt_remove(
+			(void**)&self->plat.ssl.sessions,
+			self->plat.ssl.sessions,
+			(bt_compare_func_t)nyoci_openssl_session_compare,
+			(bt_delete_func_t)nyoci_openssl_session_finalize,
+			self
+		);
+	}
+
+	// Free SSL context
+	if (self->plat.ssl.ssl_ctx) {
+		SSL_CTX_free(self->plat.ssl.ssl_ctx);
+		self->plat.ssl.ssl_ctx = NULL;
+	}
+}


### PR DESCRIPTION
This pull requests fixes a memory leak in the library when using coaps (DTLS).
The memory allocated by SSL sessions internally stored, is only released in case of an error. 
This pull requests changes this behavior to release all sessions for a certain context (an nyoci instance) when calling `nyoci_release`. This fixes issue #23.

In addition, a memory initialization issue is fixed, resolving further valgrind complaints.